### PR TITLE
fix(voicenotify): use emoji microphone instead of discord emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
+.vscode/
 .env
-.vscode

--- a/VoiceNotify/package.json
+++ b/VoiceNotify/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "voicenotify.js",
   "scripts": {
-    "start": "node -r dotenv/config --experimental-json-modules ."
+    "start": "node -r dotenv/config ."
   },
   "repository": {
     "type": "git",

--- a/VoiceNotify/voicenotify.js
+++ b/VoiceNotify/voicenotify.js
@@ -5,9 +5,10 @@
 import { Client, WebhookClient, MessageMentions, MessageEmbed } from 'discord.js'
 import { initializeApp, cert } from 'firebase-admin/app'
 import { getDatabase } from 'firebase-admin/database'
+import fs from 'fs'
 import { request } from 'https'
 
-import info from './package.json'
+const packageJson = JSON.parse(fs.readFileSync('package.json'))
 
 const client = new Client()
 const hook = new WebhookClient(process.env.VOICENOTIFY_WEBHOOK_ID, process.env.VOICENOTIFY_WEBHOOK_TOKEN)
@@ -91,7 +92,7 @@ client.on('voiceStateUpdate', async ({ channel: oldChannel }, { channel, guild }
   const rolesList = settings.roles || ''
 
   // send message
-  textCh.send(`**:microphone2: A voice chat is taking place in the "${channel.name}" channel !\n${rolesList}**`)
+  textCh.send(`\`🎙️\` A voice chat is taking place in "**${channel.name}**"!\n${rolesList}`)
 })
 
 client.on('message', async (msg) => {
@@ -127,7 +128,7 @@ client.on('message', async (msg) => {
     case 'debug':
       return msg.reply(
         new MessageEmbed().setTitle('VoiceNotify – Debug').setColor('#08C754').setDescription(`
-              **version :** VoiceNotify v${info.version}
+              **version :** VoiceNotify v${packageJson.version}
               **time :** ${Date.now()}
               **lastRestart :** ${lastRestart}
               **guildId :** ${guild.id}
@@ -173,7 +174,7 @@ const updateGuildCount = (server_count) => {
 }
 
 client.on('ready', () => {
-  log(`Bot (re)started, version ${info.version}`)
+  log(`Bot (re)started, version ${packageJson.version}`)
   updateGuildCount(client.guilds.cache.size)
 })
 client.on('guildCreate', () => updateGuildCount(client.guilds.cache.size))


### PR DESCRIPTION
Here's a couple of pictures from before and after of the push notifications. Enclosing the Unicode mic emoji in backticks was as close as I could get because of the way discord auto-converts emojis to their corresponding `:...:` syntax.

![mic-old](https://user-images.githubusercontent.com/27390822/154788227-2ac490ae-ce97-4023-990b-a84fabb662a7.png)
![mic-new](https://user-images.githubusercontent.com/27390822/154788231-18056124-a0f8-493d-80d7-350e18c774fa.png)


I also switched out the experimental JSON module support for a plain old `readFileSync` and parse mostly because I was having issues running the server with it. It was telling me that I needed to add an `assert { type: 'json' }` to the import statement, but when doing that, eslint wasn't happy and wanted an additional plugin, vscode didn't recognize the syntax, and SonarLint couldn't parse the file. Rather than making significant adjustments to the package config, I figured it would be the lesser evil to go back to a more primitive way of obtaining the package.json info.